### PR TITLE
UDOIT: make logfiles configurable (iss. #3)

### DIFF
--- a/udoit/Dockerfile.umich
+++ b/udoit/Dockerfile.umich
@@ -19,7 +19,8 @@ RUN sed -i \
 RUN mkdir /var/lib/nginx/body /var/lib/nginx/fastcgi /var/lib/nginx/proxy \
         /var/lib/nginx/uwsgi /var/lib/nginx/scgi /etc/nginx/templates && \
     chown -R root:root /var/lib/nginx/ /var/log/nginx && \
-    chmod g+rw -R /var/lib/nginx /var/log/nginx /etc/nginx/sites-available
+    chmod g+rw -R /var/lib/nginx /var/log/nginx /etc/nginx/sites-available \
+        /etc/nginx/conf.d
 
 COPY ./config/entrypoint.sh /etc/entrypoint.sh
 COPY ./config/pre-start.sh /etc/pre-start.sh

--- a/udoit/Dockerfile.umich
+++ b/udoit/Dockerfile.umich
@@ -7,22 +7,25 @@ RUN chmod g+w /etc/passwd
 # Edit nginx config file in place
 RUN sed -i \
     # Change access.log
-    -e 's|/var/log/nginx/access.log|/dev/stdout|g' \
+    # -e 's|/var/log/nginx/access.log|/dev/stdout|g' \
     # Change error.log
-    -e 's|/var/log/nginx/error.log|/dev/stdout info|g' \
+    # -e 's|/var/log/nginx/error.log|/dev/stdout info|g' \
     # Change pid location
     -e 's|/run/nginx.pid|/tmp/nginx.pid|g' /etc/nginx/nginx.conf \
     # Delete user line
     -e '/^user/d' /etc/nginx/nginx.conf
 
 # For nginx as non root
-RUN mkdir /var/lib/nginx/body /var/lib/nginx/fastcgi /var/lib/nginx/proxy /var/lib/nginx/uwsgi /var/lib/nginx/scgi && \
+RUN mkdir /var/lib/nginx/body /var/lib/nginx/fastcgi /var/lib/nginx/proxy \
+        /var/lib/nginx/uwsgi /var/lib/nginx/scgi /etc/nginx/templates && \
     chown -R root:root /var/lib/nginx/ /var/log/nginx && \
     chmod g+rw -R /var/lib/nginx /var/log/nginx /etc/nginx/sites-available
 
 COPY ./config/entrypoint.sh /etc/entrypoint.sh
 COPY ./config/pre-start.sh /etc/pre-start.sh
 RUN chmod +x /etc/entrypoint.sh /etc/pre-start.sh
+
+COPY ./config/default.conf.template /etc/nginx/templates/default.conf.template
 
 # Copy over the files
 WORKDIR /var/www/html

--- a/udoit/Dockerfile.umich
+++ b/udoit/Dockerfile.umich
@@ -6,16 +6,14 @@ RUN chmod g+w /etc/passwd
 
 # For nginx as non root
 RUN mkdir /var/lib/nginx/body /var/lib/nginx/fastcgi /var/lib/nginx/proxy \
-        /var/lib/nginx/uwsgi /var/lib/nginx/scgi /etc/nginx/templates && \
+        /var/lib/nginx/uwsgi /var/lib/nginx/scgi && \
     chown -R root:root /var/lib/nginx/ /var/log/nginx && \
     chmod g+rw -R /var/lib/nginx /var/log/nginx /etc/nginx/sites-available \
-        /etc/nginx/conf.d
+        /etc/nginx
 
 COPY ./config/entrypoint.sh /etc/entrypoint.sh
 COPY ./config/pre-start.sh /etc/pre-start.sh
 RUN chmod +x /etc/entrypoint.sh /etc/pre-start.sh
-
-COPY ./config/default.conf.template /etc/nginx/templates/default.conf.template
 
 # Copy over the files
 WORKDIR /var/www/html

--- a/udoit/Dockerfile.umich
+++ b/udoit/Dockerfile.umich
@@ -4,17 +4,6 @@ FROM ghcr.io/ucfopen/udoit:dev-v3-3-1
 # RUN useradd -g root -m -s /bin/bash -l -o -u 1000940000 www-data &&
 RUN chmod g+w /etc/passwd
 
-# Edit nginx config file in place
-RUN sed -i \
-    # Change access.log
-    # -e 's|/var/log/nginx/access.log|/dev/stdout|g' \
-    # Change error.log
-    # -e 's|/var/log/nginx/error.log|/dev/stdout info|g' \
-    # Change pid location
-    -e 's|/run/nginx.pid|/tmp/nginx.pid|g' /etc/nginx/nginx.conf \
-    # Delete user line
-    -e '/^user/d' /etc/nginx/nginx.conf
-
 # For nginx as non root
 RUN mkdir /var/lib/nginx/body /var/lib/nginx/fastcgi /var/lib/nginx/proxy \
         /var/lib/nginx/uwsgi /var/lib/nginx/scgi /etc/nginx/templates && \

--- a/udoit/config/default.conf.template
+++ b/udoit/config/default.conf.template
@@ -1,2 +1,0 @@
-access_log ${NGINX_ACCESS_LOG};
-error_log ${NGINX_ERROR_LOG};

--- a/udoit/config/default.conf.template
+++ b/udoit/config/default.conf.template
@@ -1,0 +1,2 @@
+access_log ${NGINX_ACCESS_LOG};
+error_log ${NGINX_ERROR_LOG};

--- a/udoit/config/pre-start.sh
+++ b/udoit/config/pre-start.sh
@@ -7,7 +7,16 @@ if [ "$(id -u)" -ge 1000 ]; then
   rm /tmp/passwd
 fi
 
-sed -i -e "s/\(fastcgi_read_timeout\) 180;/\1 ${FASTCGI_READ_TIMEOUT=180};/" \
+# set default values, in case they weren't specified
+FASTCGI_READ_TIMEOUT="${FASTCGI_READ_TIMEOUT=180}"
+NGINX_ACCESS_LOG="${NGINX_ACCESS_LOG=/var/log/nginx/project_access.log}"
+NGINX_ERROR_LOG="${NGINX_ERROR_LOG=/var/log/nginx/project_error.log}"
+
+# substitute values into config file
+sed -i \
+  -e "s|\(fastcgi_read_timeout\).*;|\1 ${FASTCGI_READ_TIMEOUT};|" \
+  -e "s|\(access_log\).*;|\1 ${NGINX_ACCESS_LOG};|" \
+  -e "s|\(error_log\).*;|\1 ${NGINX_ERROR_LOG};|" \
   /etc/nginx/sites-available/default
 
 if [ "${RUN_MIGRATIONS}" = true ]; then

--- a/udoit/config/pre-start.sh
+++ b/udoit/config/pre-start.sh
@@ -12,12 +12,19 @@ FASTCGI_READ_TIMEOUT="${FASTCGI_READ_TIMEOUT=180}"
 NGINX_ACCESS_LOG="${NGINX_ACCESS_LOG=/var/log/nginx/project_access.log}"
 NGINX_ERROR_LOG="${NGINX_ERROR_LOG=/var/log/nginx/project_error.log}"
 
-# substitute values into config file
+# substitute values into config files
 sed -i \
   -e "s|\(fastcgi_read_timeout\).*;|\1 ${FASTCGI_READ_TIMEOUT};|" \
   -e "s|\(access_log\).*;|\1 ${NGINX_ACCESS_LOG};|" \
   -e "s|\(error_log\).*;|\1 ${NGINX_ERROR_LOG};|" \
   /etc/nginx/sites-available/default
+
+sed -i \
+  -e "s|\(access_log\).*;|\1 ${NGINX_ACCESS_LOG};|" \
+  -e "s|\(error_log\).*;|\1 ${NGINX_ERROR_LOG};|" \
+  -e 's|/run/nginx.pid|/tmp/nginx.pid|g' \
+  -e '/^user/d' \
+  /etc/nginx/nginx.conf
 
 if [ "${RUN_MIGRATIONS}" = true ]; then
   # Run migrations

--- a/udoit/docker-compose.yaml
+++ b/udoit/docker-compose.yaml
@@ -26,6 +26,8 @@ services:
       APP_LMS: canvas
       RUN_MIGRATIONS: "true"
       FASTCGI_READ_TIMEOUT: 360
+      NGINX_ACCESS_LOG: "/dev/stdout"
+      NGINX_ERROR_LOG: "/dev/stdout info"
 
     container_name: udoit_php
     user: 1001320000:10000


### PR DESCRIPTION
Resolves #3.

Replace the log file locations in nginx configuration files `/etc/nginx/nginx.conf` and `/etc/nginx/sites-available/default` with values of environment variables `NGINX_ACCESS_LOG` and `NGINX_ERROR_LOG`, if they are set.

## Implementation note
Recent nginx images (v1.19 and newer) on Docker Hub include a feature to replace environment variable references in configuration file templates using `envsubst`.  At first, I was inspired to implement something similar.  However, that has some drawbacks:

* `envsubst` would need to be installed.  This is a minor problem, but it is an additional dependency.
* `envsubst` cannot use default values for variables if they are not set, like in Bash's `${FUBAR=default_value}` syntax.
* Various alternative versions of `envsubst` exist that support variable default values, but each requires installing interpreters for Python, Go, or Rust, which is a greater dependency problem.

For that reason, I've settled for ensuring specific variables have default values and use `sed` to replace them in the configuration files.

## Testing
Run with…

```sh
docker compose up --build
```

### Check the current FastCGI timeout value

While the container is running with Docker Compose…

```sh
docker compose exec php grep _log /etc/nginx/sites-available/default /etc/nginx/nginx.conf
```

### Change FastCGI timeout

To change the value of the log destinations…

1. Stop the Docker Compose container, if running.
2. Edit `udoit/docker-compose.yaml`.
3. Change the values of the `NGINX_*_LOG` environment variables in the `php` service.
4. Start the container again.