### PR TITLE
change Apache port & compiled views directory (iss. #20 & #21)

### DIFF
--- a/canvas-peer-grade-calculator/.env.sample
+++ b/canvas-peer-grade-calculator/.env.sample
@@ -15,6 +15,10 @@ APP_DEBUG=true
 # The base URL that this app is being served from.
 APP_URL=http://localhost
 
+# Directory where Laravel stores compiled view templates.
+# Default: `/var/www/html/storage/framework/views`
+VIEW_COMPILED_PATH=/tmp
+
 # The access ID and key of the Canvas API key.
 # Info: `longhornopen/canvas-peer-grade-calculator/web/README.md`.
 CANVAS_DEVELOPER_ACCESS_ID=

--- a/canvas-peer-grade-calculator/Dockerfile.umich
+++ b/canvas-peer-grade-calculator/Dockerfile.umich
@@ -1,4 +1,12 @@
 FROM ghcr.io/longhornopen/canvaspeergrade:20230306
 
 # https://documentation.its.umich.edu/node/2118
-RUN useradd -g root -m -s /bin/bash -l -o -u 1000940000 www-root
+#RUN useradd -g root -m -s /bin/bash -l -o -u 1000940000 www-root
+#1001160000/10000
+RUN useradd -g root -m -s /bin/bash -l -o -u 1001160000 www-root
+
+
+#RUN sed -i s/"Listen 80"/"Listen 8080"/ /etc/apache2/ports.conf
+#RUN sed -i s/"VirtualHost \*:80"/"VirtualHost \*:8080"/ /etc/apache2/sites-available/000-default.conf
+# Expose the new port
+#EXPOSE 8080

--- a/canvas-peer-grade-calculator/Dockerfile.umich
+++ b/canvas-peer-grade-calculator/Dockerfile.umich
@@ -1,12 +1,12 @@
 FROM ghcr.io/longhornopen/canvaspeergrade:20230306
 
 # https://documentation.its.umich.edu/node/2118
-#RUN useradd -g root -m -s /bin/bash -l -o -u 1000940000 www-root
+RUN useradd -g root -m -s /bin/bash -l -o -u 1000940000 www-root
 #1001160000/10000
-RUN useradd -g root -m -s /bin/bash -l -o -u 1001160000 www-root
+#RUN useradd -g root -m -s /bin/bash -l -o -u 1001160000 www-root
 
 
-#RUN sed -i s/"Listen 80"/"Listen 8080"/ /etc/apache2/ports.conf
-#RUN sed -i s/"VirtualHost \*:80"/"VirtualHost \*:8080"/ /etc/apache2/sites-available/000-default.conf
+RUN sed -i s/"Listen 80"/"Listen 8080"/ /etc/apache2/ports.conf
+RUN sed -i s/"VirtualHost \*:80"/"VirtualHost \*:8080"/ /etc/apache2/sites-available/000-default.conf
 # Expose the new port
-#EXPOSE 8080
+EXPOSE 8080

--- a/canvas-peer-grade-calculator/Dockerfile.umich
+++ b/canvas-peer-grade-calculator/Dockerfile.umich
@@ -2,11 +2,10 @@ FROM ghcr.io/longhornopen/canvaspeergrade:20230306
 
 # https://documentation.its.umich.edu/node/2118
 RUN useradd -g root -m -s /bin/bash -l -o -u 1000940000 www-root
-#1001160000/10000
-#RUN useradd -g root -m -s /bin/bash -l -o -u 1001160000 www-root
 
+# Change Apache config to use non-privileged port, 8080
+RUN sed -i 's/Listen 80/Listen 8080/' /etc/apache2/ports.conf
+RUN sed -i 's/VirtualHost \*:80/VirtualHost *:8080/' /etc/apache2/sites-available/000-default.conf
 
-RUN sed -i s/"Listen 80"/"Listen 8080"/ /etc/apache2/ports.conf
-RUN sed -i s/"VirtualHost \*:80"/"VirtualHost \*:8080"/ /etc/apache2/sites-available/000-default.conf
 # Expose the new port
 EXPOSE 8080

--- a/canvas-peer-grade-calculator/docker-compose.yaml
+++ b/canvas-peer-grade-calculator/docker-compose.yaml
@@ -9,8 +9,6 @@ services:
       - .env
     depends_on:
       - db
-    #links:
-      #- "db:db"
     ports:
       - "8000:8080"
     container_name: peer_grading_app

--- a/canvas-peer-grade-calculator/docker-compose.yaml
+++ b/canvas-peer-grade-calculator/docker-compose.yaml
@@ -12,7 +12,7 @@ services:
     #links:
       #- "db:db"
     ports:
-      - "8000:80"
+      - "8000:8080"
     container_name: peer_grading_app
 
   db:

--- a/qualtrics-lti/Dockerfile.umich
+++ b/qualtrics-lti/Dockerfile.umich
@@ -9,3 +9,10 @@ COPY custom.css public/custom/
 
 # https://documentation.its.umich.edu/node/2118
 RUN useradd -g root -m -s /bin/bash -l -o -u 1000940000 www-root
+
+# Change Apache config to use non-privileged port, 8080
+RUN sed -i 's/Listen 80/Listen 8080/' /etc/apache2/ports.conf
+RUN sed -i 's/VirtualHost \*:80/VirtualHost *:8080/' /etc/apache2/sites-available/000-default.conf
+
+# Expose the new port
+EXPOSE 8080

--- a/qualtrics-lti/docker-compose.yml
+++ b/qualtrics-lti/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.3'
 
 services:
   web:
-    build: 
+    build:
       context: .
       dockerfile: Dockerfile.umich
     environment:
@@ -21,7 +21,7 @@ services:
     links:
       - "mysql:mysql"
     ports:
-      - "8080:80"
+      - "8080:8080"
   mysql:
     image: mysql:8
     environment:


### PR DESCRIPTION
Resolves #20.
Resolves #21.

Use `/tmp` to hold the compiled views instead of the default `/var/www/html/storage/framework/views`, which is read-only on OpenShift.