### PR TITLE
DRAFT: upgrade to peer-grade version 20230418

### DIFF
--- a/canvas-peer-grade-calculator/Dockerfile.umich
+++ b/canvas-peer-grade-calculator/Dockerfile.umich
@@ -1,4 +1,4 @@
-FROM ghcr.io/longhornopen/canvaspeergrade:20230306
+FROM ghcr.io/longhornopen/canvaspeergrade:20230418
 
 # https://documentation.its.umich.edu/node/2118
 RUN useradd -g root -m -s /bin/bash -l -o -u 1000940000 www-root


### PR DESCRIPTION
Upgrading to release 20230418 of the Longhorn Open Canvas Peer Grade app.  This may address some issues raised by recent U-M faculty reviews of the app.

See: https://github.com/longhornopen/canvas-peer-grade-calculator/pkgs/container/canvaspeergrade